### PR TITLE
support vscode formatter extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "thirft-formatter",
 	"displayName": "Thirft Formatter",
 	"description": "Thrift file formatter, keeping and align comment, patch the miss",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"engines": {
 		"vscode": "^1.67.0"
 	},
@@ -14,10 +14,16 @@
 		"formatter"
 	],
 	"activationEvents": [
+		"onLanguage:thrift",
 		"onCommand:thirft-formatter.formatThriftFile"
 	],
 	"browser": "./dist/web/extension.js",
 	"contributes": {
+		"languages": [{
+			"id": "thrift",
+			"extensions": [ ".thrift", ".Thrift" ],
+			"aliases": [ "Thrift", "thrift" ]
+		}],
 		"commands": [
 			{
 				"command": "thirft-formatter.formatThriftFile",

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -24,8 +24,6 @@ export function activate(context: vscode.ExtensionContext) {
 		const config = vscode.workspace.getConfiguration('thirftFormatter');
 		const patch = config.get<boolean>('patch');
 		const indent = config.get<number>('indent');
-		// vscode.window.showInformationMessage(`thrift-formatter patch: ${patch}`);
-		// vscode.window.showInformationMessage(`thrift-formatter indent: ${indent}`);
 
 		const { document } = vscode.window.activeTextEditor;
 		const content = document.getText();
@@ -41,6 +39,31 @@ export function activate(context: vscode.ExtensionContext) {
 					new vscode.Range(0, 0, document.lineCount, 0), fmtContent);
 			})
 			vscode.window.showInformationMessage('Thrift file has been formatted');
+		}
+	});
+
+	// 👍 formatter implemented using API
+	vscode.languages.registerDocumentFormattingEditProvider('thrift', {
+		provideDocumentFormattingEdits(document: vscode.TextDocument): vscode.TextEdit[] {
+			const config = vscode.workspace.getConfiguration('thirftFormatter');
+			const patch = config.get<boolean>('patch');
+			const indent = config.get<number>('indent');
+
+			const content = document.getText();
+			if (content === "") {
+				vscode.window.showInformationMessage('No content to format.');
+				return [];
+			}
+
+			const [fmtContent, needUpdate] = formatThrift(content, patch || false, indent);
+
+			if (needUpdate) {
+				return [
+					vscode.TextEdit.replace(
+						new vscode.Range(0, 0, document.lineCount, 0), fmtContent)
+				];
+			}
+		return [];
 		}
 	});
 


### PR DESCRIPTION
fix #4 

see https://code.visualstudio.com/blogs/2016/11/15/formatters-best-practices

https://github.com/jrieken/vscode-formatter-sample/issues

and https://code.visualstudio.com/api/language-extensions/overview